### PR TITLE
Added read replica and multi az support

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -118,7 +118,7 @@ variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
   # default     = "aurora-mysql5.7"
-  default     = "mysql5.7"
+  default     = "mysql8.0"
   # default = "aurora-mysql8.0"
 }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -117,8 +117,8 @@ variable "subnet_ids" {
 variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
-  # default     = "aurora-mysql5.7"
-  default = "aurora-mysql8.0"
+  default     = "aurora-mysql5.7"
+  # default = "aurora-mysql8.0"
 }
 
 variable "engine" {
@@ -130,7 +130,7 @@ variable "engine" {
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
-  default     = "8.0.mysql_aurora.3.04.0"
+  default     = "5.7.mysql_aurora.2.11.2"
   # default = "8.0.34"
 }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -190,7 +190,8 @@ variable "maintenance_window" {
 variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   type        = bool
-  default     = true
+  # default     = true
+  default = false
 }
 
 variable "instance_class" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,7 +7,8 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  default     = true
+  # default     = true
+  default     = false
 }
 
 variable "database_module" {
@@ -116,19 +117,22 @@ variable "subnet_ids" {
 variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql8.0) or postgresql(aurora-postgresql15)"
-  default = "aurora-mysql8.0"
+  # default = "aurora-mysql8.0"
+  default = "mysql8.0"
 }
 
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  default     = "aurora-mysql"
+  # default     = "aurora-mysql"
+  default     = "mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(8.0.mysql_aurora.3.02.0, 8.0) or postgresql(13.6)"
-  default     = "8.0.mysql_aurora.3.02.0"
+  # default     = "8.0.mysql_aurora.3.02.0"
+  default     = "8.0"
 }
 
 variable "multi_az" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -139,7 +139,7 @@ variable "multi_az" {
 
 variable "read_replica" {
   type        = bool
-  description = "Make this true if you want to deploy a read replica of mysql DB Instance"
+  description = "Make this true if you want to deploy a read replica of Aurora instance or mysql DB Instance"
   default = false
 }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,8 +7,8 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  # default     = true
-  default     = false
+  default     = true
+  # default     = false
 }
 
 variable "database_module" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -118,20 +118,20 @@ variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
   # default     = "aurora-mysql5.7"
-  default = "mysql8.0"
+  default = "aurora-mysql8.0"
 }
 
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  default     = "mysql"
+  default     = "aurora-mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
-  # default     = "5.7.mysql_aurora.2.11.2"
-  default = "8.0.34"
+  default     = "8.0.mysql_aurora.3.04.0"
+  # default = "8.0.34"
 }
 
 variable "availability_zones" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -137,6 +137,12 @@ variable "multi_az" {
   default = false
 }
 
+variable "read_replica" {
+  type        = bool
+  description = "Make this true if you want to deploy a read replica of mysql DB Instance"
+  default = false
+}
+
 variable "availability_zones" {
   type    = list(string)
   default = []

--- a/_variables.tf
+++ b/_variables.tf
@@ -118,7 +118,7 @@ variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
   # default     = "aurora-mysql5.7"
-  default = "aurora-mysql8.0"
+  default = "mysql8.0"
 }
 
 variable "engine" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,8 +7,7 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  # default     = true
-  default     = false
+  default     = true
 }
 
 variable "database_module" {
@@ -117,22 +116,19 @@ variable "subnet_ids" {
 variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql8.0) or postgresql(aurora-postgresql15)"
-  # default = "aurora-mysql8.0"
-  default = "mysql8.0"
+  default = "aurora-mysql8.0"
 }
 
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  # default     = "aurora-mysql"
-  default     = "mysql"
+  default     = "aurora-mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(8.0.mysql_aurora.3.02.0, 8.0) or postgresql(13.6)"
-  # default     = "8.0.mysql_aurora.3.02.0"
-  default     = "8.0"
+  default     = "8.0.mysql_aurora.3.02.0"
 }
 
 variable "multi_az" {
@@ -144,7 +140,7 @@ variable "multi_az" {
 variable "read_replica" {
   type        = bool
   description = "Make this true if you want to deploy a read replica of mysql DB Instance"
-  default = true
+  default = false
 }
 
 variable "availability_zones" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -127,7 +127,7 @@ variable "engine" {
 
 variable "engine_version" {
   type        = string
-  description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
+  description = "The name of the database engine to be used for this DB cluster for mysql(8.0.mysql_aurora.3.02.0, 8.0) or postgresql(13.6)"
   default     = "8.0.mysql_aurora.3.02.0"
 }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -249,13 +249,13 @@ variable "kms_key_arn" {
 variable "allocated_storage" {
   type        = number
   description = "Storage size in GB"
-  default     = 10
+  default     = 20
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "Argument higher than the allocated_storage to enable Storage Autoscaling, size in GB. 0 to disable Storage Autoscaling"
-  default     = 20
+  default     = 50
 }
 
 variable "storage_type" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,8 +7,8 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  # default     = true
-  default     = false
+  default     = true
+  # default     = false
 }
 
 variable "database_module" {
@@ -118,22 +118,22 @@ variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
   # default     = "aurora-mysql5.7"
-  default     = "mysql8.0"
-  # default = "aurora-mysql8.0"
+  # default     = "mysql8.0"
+  default = "aurora-mysql8.0"
 }
 
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  # default     = "aurora-mysql"
-  default     = "mysql"
+  default     = "aurora-mysql"
+  # default     = "mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
-  # default     = "5.7.mysql_aurora.2.11.2"
-  default = "8.0.34"
+  default     = "8.0.mysql_aurora.3.02.0"
+  # default = "8.0.34"
 }
 
 variable "multi_az" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -117,21 +117,23 @@ variable "subnet_ids" {
 variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
-  default     = "aurora-mysql5.7"
+  # default     = "aurora-mysql5.7"
+  default     = "mysql5.7"
   # default = "aurora-mysql8.0"
 }
 
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  default     = "aurora-mysql"
+  # default     = "aurora-mysql"
+  default     = "mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
-  default     = "5.7.mysql_aurora.2.11.2"
-  # default = "8.0.34"
+  # default     = "5.7.mysql_aurora.2.11.2"
+  default = "8.0.34"
 }
 
 variable "availability_zones" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -262,13 +262,13 @@ variable "kms_key_arn" {
 variable "allocated_storage" {
   type        = number
   description = "Storage size in GB"
-  default     = 10
+  default     = 20
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "Argument higher than the allocated_storage to enable Storage Autoscaling, size in GB. 0 to disable Storage Autoscaling"
-  default     = 20
+  default     = 50
 }
 
 variable "storage_type" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,8 +7,8 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  default     = true
-  # default     = false
+  # default     = true
+  default     = false
 }
 
 variable "database_module" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -124,14 +124,14 @@ variable "parameter_family" {
 variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
-  default     = "aurora-mysql"
+  default     = "mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
   # default     = "5.7.mysql_aurora.2.11.2"
-  default = "8.0.mysql_aurora.3.04.0"
+  default = "8.0.34"
 }
 
 variable "availability_zones" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -136,7 +136,8 @@ variable "engine_version" {
 
 variable "availability_zones" {
   type    = list(string)
-  default = []
+  # default = []
+  default = [ "us-east-1a", "us-east-1b", "us-east-1c" ]
 }
 
 variable "database_name" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -136,6 +136,12 @@ variable "engine_version" {
   default = "8.0.34"
 }
 
+variable "multi_az" {
+  type        = bool
+  description = "Make this true if you want to deploy a multi az mysql DB Instance"
+  default = true
+}
+
 variable "availability_zones" {
   type    = list(string)
   # default = []

--- a/_variables.tf
+++ b/_variables.tf
@@ -7,7 +7,8 @@ variable "name" {
 variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
-  default     = true
+  # default     = true
+  default     = false
 }
 
 variable "database_module" {
@@ -116,7 +117,8 @@ variable "subnet_ids" {
 variable "parameter_family" {
   type        = string
   description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
-  default     = "aurora-mysql5.7"
+  # default     = "aurora-mysql5.7"
+  default = "aurora-mysql8.0"
 }
 
 variable "engine" {
@@ -128,7 +130,8 @@ variable "engine" {
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
-  default     = "5.7.mysql_aurora.2.11.2"
+  # default     = "5.7.mysql_aurora.2.11.2"
+  default = "8.0.mysql_aurora.3.04.0"
 }
 
 variable "availability_zones" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -8,7 +8,6 @@ variable "create_aurora" {
   type        = bool
   description = "If you want to create Aurora MySQL or PostgreSQL enable this check"
   default     = true
-  # default     = false
 }
 
 variable "database_module" {
@@ -116,9 +115,7 @@ variable "subnet_ids" {
 
 variable "parameter_family" {
   type        = string
-  description = "The family of the DB parameter group for mysql(aurora-mysql5.7) or postgresql(aurora-postgresql15)"
-  # default     = "aurora-mysql5.7"
-  # default     = "mysql8.0"
+  description = "The family of the DB parameter group for mysql(aurora-mysql8.0) or postgresql(aurora-postgresql15)"
   default = "aurora-mysql8.0"
 }
 
@@ -126,26 +123,24 @@ variable "engine" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(aurora-mysql, mysql) or postgresql(aurora-postgresql, postgresql)"
   default     = "aurora-mysql"
-  # default     = "mysql"
 }
 
 variable "engine_version" {
   type        = string
   description = "The name of the database engine to be used for this DB cluster for mysql(5.7.mysql_aurora.2.10.2, 5.7) or postgresql(13.6)"
   default     = "8.0.mysql_aurora.3.02.0"
-  # default = "8.0.34"
 }
 
 variable "multi_az" {
   type        = bool
   description = "Make this true if you want to deploy a multi az mysql DB Instance"
-  default = true
+  default = false
 }
 
 variable "availability_zones" {
   type    = list(string)
-  # default = []
-  default = [ "us-east-1a", "us-east-1b", "us-east-1c" ]
+  default = []
+  # default = [ "us-east-1a", "us-east-1b", "us-east-1c" ]
 }
 
 variable "database_name" {
@@ -198,8 +193,7 @@ variable "maintenance_window" {
 variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   type        = bool
-  # default     = true
-  default = false
+  default     = true
 }
 
 variable "instance_class" {
@@ -258,13 +252,13 @@ variable "kms_key_arn" {
 variable "allocated_storage" {
   type        = number
   description = "Storage size in GB"
-  default     = 20
+  default     = 10
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "Argument higher than the allocated_storage to enable Storage Autoscaling, size in GB. 0 to disable Storage Autoscaling"
-  default     = 50
+  default     = 20
 }
 
 variable "storage_type" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -144,7 +144,7 @@ variable "multi_az" {
 variable "read_replica" {
   type        = bool
   description = "Make this true if you want to deploy a read replica of mysql DB Instance"
-  default = false
+  default = true
 }
 
 variable "availability_zones" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "mysql_database" {
   source = "git::https://github.com/narenderttn/terraform-aws-rds.git"
 
-  subnet_ids = ["subnet-7c16341b", "subnet-b2b59c9c"]
-  vpc_id     = "vpc-855826ff"
+  subnet_ids = ["subnet-043d59b3957d49e1d", "subnet-093641ce3f549831e"]
+  vpc_id     = "vpc-0c7ca42512bbbb3df"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,5 +1,5 @@
 module "mysql_database" {
-  source = "git::https://github.com/tothenew/terraform-aws-rds.git"
+  source = "git::https://github.com/narenderttn/terraform-aws-rds.git"
 
   subnet_ids = ["subnet-7c16341b", "subnet-b2b59c9c"]
   vpc_id     = "vpc-855826ff"

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "mysql_database" {
   source = "git::https://github.com/narenderttn/terraform-aws-rds.git"
 
-  subnet_ids = ["subnet-043d59b3957d49e1d", "subnet-093641ce3f549831e"]
+  subnet_ids = ["subnet-043d59b3957d49e1d", "subnet-093641ce3f549831e", "subnet-0d911d25c86c0a429"]
   vpc_id     = "vpc-0c7ca42512bbbb3df"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "mysql_database" {
   source = "git::https://github.com/tothenew/terraform-aws-rds.git"
 
-  subnet_ids = ["subnet-043d59b3957d4", "subnet-093641ce3f549", "subnet-0d911d25c86c0"]
+  subnet_ids = ["subnet-043d59b3957d4", "subnet-093641ce3f549"]
   vpc_id     = "vpc-0c7ca42512bb"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "mysql_database" {
-  source = "git::https://github.com/tothenew/terraform-aws-rds.git"
+  source = "git::https://github.com/narenderttn/terraform-aws-rds.git"
 
-  subnet_ids = ["subnet-043d59b3957d4", "subnet-093641ce3f549"]
-  vpc_id     = "vpc-0c7ca42512bb"
+  subnet_ids = ["subnet-043d59b3957d49e1d", "subnet-093641ce3f549831e"]
+  vpc_id     = "vpc-0c7ca42512bbbb3df"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "mysql_database" {
-  source = "git::https://github.com/narenderttn/terraform-aws-rds.git"
+  source = "git::https://github.com/tothenew/terraform-aws-rds.git"
 
-  subnet_ids = ["subnet-043d59b3957d49e1d", "subnet-093641ce3f549831e", "subnet-0d911d25c86c0a429"]
-  vpc_id     = "vpc-0c7ca42512bbbb3df"
+  subnet_ids = ["subnet-043d59b3957d4", "subnet-093641ce3f549", "subnet-0d911d25c86c0"]
+  vpc_id     = "vpc-0c7ca42512bb"
 }

--- a/git.sh
+++ b/git.sh
@@ -1,0 +1,3 @@
+git add .
+git commit -m "changes"
+git push origin main

--- a/git.sh
+++ b/git.sh
@@ -1,3 +1,0 @@
-git add .
-git commit -m "changes"
-git push origin main

--- a/main.tf
+++ b/main.tf
@@ -88,8 +88,8 @@ resource "aws_db_instance" "rds_aurora_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
-
+  # replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id
   depends_on = [aws_rds_cluster.rds_cluster]
   
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
   allocated_storage                   = 256
   db_cluster_instance_class           = "db.r6g.large"
-  # iops                                = 2500
+  iops                                = 2500
   storage_type                        = "io1"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_instance" {
   db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
-  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
+  password                   = random_string.rds_db_password.result
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,22 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
+resource "aws_db_instance" "rds_read_replica" {
+  count                 = var.create_aurora ? 1 : 0
+  identifier            = "${local.project_name_prefix}-read-replica"
+  allocated_storage     = 256  # You can adjust this as needed
+  storage_type          = "gp2"  # You can adjust the storage type as needed
+  engine                = aws_rds_cluster.rds_cluster[0].engine
+  engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
+  instance_class        = var.instance_class  # Specify the desired instance type
+  db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+  db_parameter_group_name = aws_db_parameter_group.parameter_group[0].name  # Use the same parameter group as the cluster
+  source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id  # Specify the cluster identifier as the source
+
+  tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
+}
+
+
 resource "aws_db_instance" "rds_instance" {
   count                      = var.create_aurora ? 0 : 1
   publicly_accessible        = var.publicly_accessible

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ resource "aws_rds_cluster" "rds_cluster" {
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
   port                                = var.port
   apply_immediately                   = var.apply_immediately
-  replica_count                       = 2
   tags                                = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
@@ -80,21 +79,21 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-# resource "aws_db_instance" "rds_aurora_read_replica" {
-#   count                 = var.create_aurora ? 1 : 0
-#   identifier            = "${local.project_name_prefix}-read-replica"
-#   allocated_storage     = 256  # You can adjust this as needed
-#   storage_type          = "gp2"  # You can adjust the storage type as needed
-#   engine                = aws_rds_cluster.rds_cluster[0].engine
-#   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
-#   instance_class        = var.instance_class  # Specify the desired instance type
-#   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-#   replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+resource "aws_db_instance" "rds_aurora_read_replica" {
+  count                 = var.create_aurora ? 1 : 0
+  identifier            = "${local.project_name_prefix}-read-replica"
+  allocated_storage     = 256  # You can adjust this as needed
+  storage_type          = "gp2"  # You can adjust the storage type as needed
+  engine                = aws_rds_cluster.rds_cluster[0].engine
+  engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
+  instance_class        = var.instance_class  # Specify the desired instance type
+  db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
 
-#   depends_on = [aws_rds_cluster.rds_cluster]
+  depends_on = [aws_rds_cluster.rds_cluster]
   
-#   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
-# }
+  tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
+}
 
 
 resource "aws_db_instance" "rds_instance" {

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  # db_cluster_instance_class           = "db.r6gd.xlarge"
+  # allocated_storage                   = 256
+  # db_cluster_instance_class           = "db.r6gd.large"
+  # iops                                = 2500
   # storage_type                        = "io1"
-  # allocated_storage                   = "100"
-  # iops                                = "1000"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -76,20 +76,22 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-
-resource "aws_db_instance" "rds_cluster_instance_read_replica" {
-  count                        = var.create_aurora ? 1 : 0
-  identifier                   = local.project_name_prefix
-  engine                       = aws_rds_cluster.rds_cluster[0].engine
-  engine_version               = aws_rds_cluster.rds_cluster[0].engine_version
-  db_subnet_group_name         = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  instance_class               = var.instance_class
-  apply_immediately            = var.apply_immediately
-  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
-  publicly_accessible          = var.publicly_accessible
-  tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
-  replicate_source_db          = aws_rds_cluster_instance.rds_cluster_instance[0].arn
+resource "aws_rds_cluster_instance" "read_replica" {
+  count                           = var.create_data_reader && var.create_resources ? 1 : 0
+  identifier                      = "${local.project_name_prefix}-read-replica"
+  cluster_identifier              = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  engine                          = var.engine
+  engine_version                  = var.engine_version
+  instance_class                  = var.data_reader_instance_type
+  publicly_accessible             = var.publicly_accessible
+  db_subnet_group_name            = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+  db_parameter_group_name         = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
+  preferred_maintenance_window    = var.maintenance_window
+  apply_immediately               = var.apply_immediately
+  auto_minor_version_upgrade      = var.auto_minor_version_upgrade
+  tags                            = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
 }
+
 
 resource "aws_db_instance" "rds_instance" {
   count                      = var.create_aurora ? 0 : 1

--- a/main.tf
+++ b/main.tf
@@ -79,20 +79,24 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-# resource "aws_db_instance" "rds_aurora_read_replica" {
-#   count                 = var.create_aurora ? 1 : 0
-#   identifier            = "${local.project_name_prefix}-read-replica"
-#   allocated_storage     = 256  # You can adjust this as needed
-#   storage_type          = "gp2"  # You can adjust the storage type as needed
-#   engine                = aws_rds_cluster.rds_cluster[0].engine
-#   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
-#   instance_class        = var.instance_class  # Specify the desired instance type
-#   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-#   replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
-#   depends_on = [aws_rds_cluster.rds_cluster]
+resource "aws_rds_cluster_instance" "rds_cluster_instance_read_replica" {
+  count                        = var.create_aurora ? 1 : 0
+  identifier                   = local.project_name_prefix
+  cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  engine                       = aws_rds_cluster.rds_cluster[0].engine
+  engine_version               = aws_rds_cluster.rds_cluster[0].engine_version
+  db_subnet_group_name         = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+  db_parameter_group_name      = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
+  instance_class               = var.instance_class
+  preferred_maintenance_window = var.maintenance_window
+  apply_immediately            = var.apply_immediately
+  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
+  publicly_accessible          = var.publicly_accessible
   
-#   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
-# }
+  replicate_source_db          = aws_rds_cluster_instance.rds_cluster_instance[0].arn
+  
+  tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
+}
 
 
 resource "aws_db_instance" "rds_instance" {

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
+  db_cluster_instance_class           = var.instance_class
+  storage_type                        = var.storage_type
+  allocated_storage                   = var.allocated_storage
+  iops                                = 1000
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -38,9 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  db_cluster_instance_class           = var.instance_class
-  storage_type                        = var.storage_type
-  allocated_storage                   = var.allocated_storage
+  db_cluster_instance_class           = "db.r6gd.xlarge"
+  storage_type                        = "io1"
+  allocated_storage                   = "100"
+  iops                                = "1000"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,6 @@ resource "aws_db_instance" "rds_instance" {
   db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
-  # password                   = var.master_password
   password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
@@ -118,11 +117,10 @@ resource "aws_db_instance" "rds_instance" {
   skip_final_snapshot        = var.skip_final_snapshot
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
-  
   multi_az                   = var.multi_az
 }
 
-resource "aws_db_instance" "rds_instance_read_replica" {
+resource "aws_db_instance" "read_replica" {
   count                      = var.create_aurora ? 0 : 1
   publicly_accessible        = var.publicly_accessible
   allocated_storage          = var.allocated_storage

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_db_instance" "rds_instance" {
   username                   = var.master_username
   # password                   = var.master_password
   # password                   = random_string.rds_db_password.result
-  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
+  password                   = "narender"
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -88,8 +88,8 @@ resource "aws_db_instance" "rds_aurora_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  # replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
-  source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id
+  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  # source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id
   depends_on = [aws_rds_cluster.rds_cluster]
   
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,6 @@ resource "aws_rds_cluster" "rds_cluster" {
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
   port                                = var.port
   apply_immediately                   = var.apply_immediately
-  replication_source_identifier       = "${aws_db_instance.rds_cluster_instance_read_replica.arn}"
   tags                                = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,7 @@ resource "aws_db_instance" "rds_instance_read_replica" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
 
+  multi_az                   = var.multi_az
   replicate_source_db        = aws_db_instance.rds_instance[0].arn
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_rds_cluster" "rds_cluster" {
 }
 
 resource "aws_rds_cluster_instance" "rds_cluster_instance" {
-  count                        = var.create_aurora ? 1 : 0
+  count                        = var.create_aurora ? 2 : 0
   identifier                   = local.project_name_prefix
   cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                       = aws_rds_cluster.rds_cluster[0].engine
@@ -79,21 +79,20 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-resource "aws_db_instance" "rds_aurora_read_replica" {
-  count                 = var.create_aurora ? 1 : 0
-  identifier            = "${local.project_name_prefix}-read-replica"
-  allocated_storage     = 256  # You can adjust this as needed
-  storage_type          = "gp2"  # You can adjust the storage type as needed
-  engine                = aws_rds_cluster.rds_cluster[0].engine
-  engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
-  instance_class        = var.instance_class  # Specify the desired instance type
-  db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
-  # source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id
-  depends_on = [aws_rds_cluster.rds_cluster]
+# resource "aws_db_instance" "rds_aurora_read_replica" {
+#   count                 = var.create_aurora ? 1 : 0
+#   identifier            = "${local.project_name_prefix}-read-replica"
+#   allocated_storage     = 256  # You can adjust this as needed
+#   storage_type          = "gp2"  # You can adjust the storage type as needed
+#   engine                = aws_rds_cluster.rds_cluster[0].engine
+#   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
+#   instance_class        = var.instance_class  # Specify the desired instance type
+#   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+#   replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+#   depends_on = [aws_rds_cluster.rds_cluster]
   
-  tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
-}
+#   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
+# }
 
 
 resource "aws_db_instance" "rds_instance" {

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,7 @@ resource "aws_db_instance" "rds_instance_read_replica" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
 
+  multi_az                   = var.multi_az
   replicate_source_db        = aws_db_instance.rds_instance[0].arn
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_aurora_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db   = "${aws_rds_cluster_instance.rds_cluster_instance.cluster_identifier}"
+  replicate_source_db   = "${aws_rds_cluster_instance.rds_cluster_instance[count.index]}"
   
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
 }

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  # db_cluster_instance_class           = var.instance_class
-  # storage_type                        = var.storage_type
-  # allocated_storage                   = var.allocated_storage
-  # iops                                = 1000
+  db_cluster_instance_class           = var.instance_class
+  storage_type                        = var.storage_type
+  allocated_storage                   = var.allocated_storage
+  iops                                = 1000
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
   allocated_storage                   = 256
-  db_cluster_instance_class           = "db.r6gd.large"
+  db_cluster_instance_class           = "db.r6g.large"
   # iops                                = 2500
   storage_type                        = "io1"
   master_username                     = var.master_username

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_db_instance" "rds_instance" {
   username                   = var.master_username
   # password                   = var.master_password
   # password                   = random_string.rds_db_password.result
-  # password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
+  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -92,8 +92,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance_read_replica" {
   apply_immediately            = var.apply_immediately
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade
   publicly_accessible          = var.publicly_accessible
-  
-  replicate_source_db          = aws_rds_cluster_instance.rds_cluster_instance[0].arn
+  writer                       = false
   
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_rds_cluster" "rds_cluster" {
 }
 
 resource "aws_rds_cluster_instance" "rds_cluster_instance" {
-  count                        = var.create_aurora ? 2 : 0
+  count                        = var.create_aurora ? 1 : 0
   identifier                   = local.project_name_prefix
   cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                       = aws_rds_cluster.rds_cluster[0].engine

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  db_parameter_group_name = aws_db_parameter_group.parameter_group[0].name  # Use the same parameter group as the cluster
+  #db_parameter_group_name = aws_db_parameter_group.parameter_group[0].name  # Use the same parameter group as the cluster
   source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id  # Specify the cluster identifier as the source
 
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_db_instance" "rds_instance" {
   username                   = var.master_username
   # password                   = var.master_password
   # password                   = random_string.rds_db_password.result
-  password                   = "foobarbaz"
+  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
 }
 
 resource "aws_rds_cluster_instance" "read_replica" {
-  count                           = var.create_aurora ? 1 : 0
+  count                           = var.create_aurora && var.read_replica ? 1 : 0
   identifier                      = "${local.project_name_prefix}-read-replica"
   cluster_identifier              = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                          = var.engine
@@ -121,7 +121,7 @@ resource "aws_db_instance" "rds_instance" {
 }
 
 resource "aws_db_instance" "read_replica" {
-  count                      = var.create_aurora ? 0 : 1
+  count                      = var.create_aurora == false && var.read_replica == true ? 1 : 0
   publicly_accessible        = var.publicly_accessible
   allocated_storage          = var.allocated_storage
   max_allocated_storage      = var.max_allocated_storage

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  # allocated_storage                   = 256
-  # db_cluster_instance_class           = "db.r6gd.large"
-  # iops                                = 2500
-  # storage_type                        = "io1"
+  allocated_storage                   = 256
+  db_cluster_instance_class           = "db.r6gd.large"
+  iops                                = 2500
+  storage_type                        = "io1"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_instance" {
   db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
-  password                   = var.master_password
+  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -79,25 +79,6 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-resource "aws_rds_cluster_instance" "rds_cluster_instance_read_replica" {
-  count                        = var.create_aurora ? 1 : 0
-  identifier                   = local.project_name_prefix
-  cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
-  engine                       = aws_rds_cluster.rds_cluster[0].engine
-  engine_version               = aws_rds_cluster.rds_cluster[0].engine_version
-  db_subnet_group_name         = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  db_parameter_group_name      = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
-  instance_class               = var.instance_class
-  preferred_maintenance_window = var.maintenance_window
-  apply_immediately            = var.apply_immediately
-  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
-  publicly_accessible          = var.publicly_accessible
-  writer                       = false
-  
-  tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
-}
-
-
 resource "aws_db_instance" "rds_instance" {
   count                      = var.create_aurora ? 0 : 1
   publicly_accessible        = var.publicly_accessible

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_db_instance" "rds_instance" {
   username                   = var.master_username
   # password                   = var.master_password
   # password                   = random_string.rds_db_password.result
-  password                   = "narender"
+  password                   = "foobarbaz"
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
   port                                = var.port
   apply_immediately                   = var.apply_immediately
+  replication_source_identifier       = "${aws_db_instance.rds_cluster_instance_read_replica.arn}"
   tags                                = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,6 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  # allocated_storage                   = 256
-  # db_cluster_instance_class           = "db.r6g.large"
-  # iops                                = 2500
-  # storage_type                        = "io1"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period
@@ -66,6 +62,7 @@ resource "aws_rds_cluster" "rds_cluster" {
 resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   count                        = var.create_aurora ? 1 : 0
   identifier                   = local.project_name_prefix
+  availability_zones           = var.availability_zones
   cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                       = aws_rds_cluster.rds_cluster[0].engine
   engine_version               = aws_rds_cluster.rds_cluster[0].engine_version

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_db_instance" "rds_instance_read_replica" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
 
-  source_db_instance_identifier = aws_db_instance.rds_instance[0].id
+  replicate_source_db        = aws_db_instance.rds_instance[0].arn
 
   tags = {
     Name = "${local.project_name_prefix}-read-replica"

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  allocated_storage                   = 256
-  db_cluster_instance_class           = "db.r6g.large"
-  iops                                = 2500
-  storage_type                        = "io1"
+  # allocated_storage                   = 256
+  # db_cluster_instance_class           = "db.r6g.large"
+  # iops                                = 2500
+  # storage_type                        = "io1"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -79,13 +79,10 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
 resource "aws_db_instance" "rds_cluster_instance_read_replica" {
   count                        = var.create_aurora ? 1 : 0
   identifier                   = local.project_name_prefix
-  cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                       = aws_rds_cluster.rds_cluster[0].engine
   engine_version               = aws_rds_cluster.rds_cluster[0].engine_version
   db_subnet_group_name         = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  db_parameter_group_name      = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
   instance_class               = var.instance_class
-  preferred_maintenance_window = var.maintenance_window
   apply_immediately            = var.apply_immediately
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade
   publicly_accessible          = var.publicly_accessible

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  db_cluster_instance_class           = var.instance_class
-  storage_type                        = var.storage_type
-  allocated_storage                   = var.allocated_storage
-  iops                                = 1000
+  # db_cluster_instance_class           = var.instance_class
+  # storage_type                        = var.storage_type
+  # allocated_storage                   = var.allocated_storage
+  # iops                                = 1000
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,9 @@ resource "aws_db_instance" "rds_aurora_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+
+  depends_on = [aws_rds_cluster.rds_cluster]
   
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
 }

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_instance" {
   db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
-  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
+  password                   = var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-resource "aws_db_instance" "rds_read_replica" {
+resource "aws_db_instance" "rds_aurora_read_replica" {
   count                 = var.create_aurora ? 1 : 0
   identifier            = "${local.project_name_prefix}-read-replica"
   allocated_storage     = 256  # You can adjust this as needed
@@ -88,9 +88,8 @@ resource "aws_db_instance" "rds_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  #db_parameter_group_name = aws_db_parameter_group.parameter_group[0].name  # Use the same parameter group as the cluster
-  source_db_instance_identifier = aws_rds_cluster.rds_cluster[0].id  # Specify the cluster identifier as the source
-
+  replicate_source_db   = "${aws_rds_cluster_instance.rds_cluster_instance.cluster_identifier}"
+  
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
 }
 

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,6 @@ resource "aws_rds_cluster" "rds_cluster" {
 resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   count                        = var.create_aurora ? 1 : 0
   identifier                   = local.project_name_prefix
-  availability_zones           = var.availability_zones
   cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                       = aws_rds_cluster.rds_cluster[0].engine
   engine_version               = aws_rds_cluster.rds_cluster[0].engine_version

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-resource "aws_db_instance" "rds_aurora_read_replica" {
+resource "aws_rds_cluster_instance" "rds_aurora_read_replica" {
   count                 = var.create_aurora ? 1 : 0
   identifier            = "${local.project_name_prefix}-read-replica"
   allocated_storage     = 256  # You can adjust this as needed

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
   port                                = var.port
   apply_immediately                   = var.apply_immediately
+  replica_count                       = 2
   tags                                = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
@@ -79,21 +80,21 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
 }
 
-resource "aws_rds_cluster_instance" "rds_aurora_read_replica" {
-  count                 = var.create_aurora ? 1 : 0
-  identifier            = "${local.project_name_prefix}-read-replica"
-  allocated_storage     = 256  # You can adjust this as needed
-  storage_type          = "gp2"  # You can adjust the storage type as needed
-  engine                = aws_rds_cluster.rds_cluster[0].engine
-  engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
-  instance_class        = var.instance_class  # Specify the desired instance type
-  db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
+# resource "aws_db_instance" "rds_aurora_read_replica" {
+#   count                 = var.create_aurora ? 1 : 0
+#   identifier            = "${local.project_name_prefix}-read-replica"
+#   allocated_storage     = 256  # You can adjust this as needed
+#   storage_type          = "gp2"  # You can adjust the storage type as needed
+#   engine                = aws_rds_cluster.rds_cluster[0].engine
+#   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
+#   instance_class        = var.instance_class  # Specify the desired instance type
+#   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+#   replicate_source_db   = aws_rds_cluster.rds_cluster[0].cluster_identifier
 
-  depends_on = [aws_rds_cluster.rds_cluster]
+#   depends_on = [aws_rds_cluster.rds_cluster]
   
-  tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
-}
+#   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
+# }
 
 
 resource "aws_db_instance" "rds_instance" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "random_string" "unique_string" {
 resource "random_string" "rds_db_password" {
   count   = var.create_username_password ? 1 : 0
   length  = 16
-  special = false
+  special = true
 }
 
 resource "aws_db_subnet_group" "subnet_group" {
@@ -88,7 +88,9 @@ resource "aws_db_instance" "rds_instance" {
   db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
-  password                   = random_string.rds_db_password.result
+  # password                   = var.master_password
+  # password                   = random_string.rds_db_password.result
+  # password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
   apply_immediately          = var.apply_immediately

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ resource "aws_rds_cluster" "rds_cluster" {
   db_cluster_instance_class           = var.instance_class
   storage_type                        = var.storage_type
   allocated_storage                   = var.allocated_storage
-  iops                                = 1000
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -122,3 +122,32 @@ resource "aws_db_instance" "rds_instance" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
 }
+
+resource "aws_db_instance" "rds_instance_read_replica" {
+  count                      = var.create_aurora ? 0 : 1
+  publicly_accessible        = var.publicly_accessible
+  allocated_storage          = var.allocated_storage
+  max_allocated_storage      = var.max_allocated_storage
+  storage_type               = var.storage_type
+  engine                     = var.engine
+  engine_version             = var.engine_version
+  identifier                 = "${local.project_name_prefix}-read-replica"
+  instance_class             = var.instance_class
+  db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
+  vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
+  apply_immediately          = var.apply_immediately
+  storage_encrypted          = var.storage_encrypted
+  kms_key_id                 = var.storage_encrypted ? aws_kms_key.kms_key[0].arn : null
+  deletion_protection        = var.deletion_protection
+  maintenance_window         = var.maintenance_window
+  backup_window              = var.preferred_backup_window
+  skip_final_snapshot        = var.skip_final_snapshot
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
+
+  source_db_instance_identifier = aws_db_instance.rds_instance[0].id
+
+  tags = {
+    Name = "${local.project_name_prefix}-read-replica"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
 }
 
 resource "aws_rds_cluster_instance" "read_replica" {
-  count                           = var.create_data_reader && var.create_resources ? 1 : 0
+  count                           = var.create_aurora ? 1 : 0
   identifier                      = "${local.project_name_prefix}-read-replica"
   cluster_identifier              = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                          = var.engine

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_rds_cluster_instance" "read_replica" {
   cluster_identifier              = aws_rds_cluster.rds_cluster[0].cluster_identifier
   engine                          = var.engine
   engine_version                  = var.engine_version
-  instance_class                  = var.data_reader_instance_type
+  instance_class                  = var.instance_class
   publicly_accessible             = var.publicly_accessible
   db_subnet_group_name            = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
   db_parameter_group_name         = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,8 @@ resource "aws_db_instance" "rds_instance" {
   skip_final_snapshot        = var.skip_final_snapshot
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
+  
+  multi_az                   = var.multi_az
 }
 
 resource "aws_db_instance" "rds_instance_read_replica" {
@@ -145,7 +147,6 @@ resource "aws_db_instance" "rds_instance_read_replica" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
 
-  multi_az                   = var.multi_az
   replicate_source_db        = aws_db_instance.rds_instance[0].arn
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,10 @@ resource "aws_rds_cluster" "rds_cluster" {
   engine_version                      = var.engine_version
   availability_zones                  = var.availability_zones
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
-  db_cluster_instance_class           = "db.r6gd.xlarge"
-  storage_type                        = "io1"
-  allocated_storage                   = "100"
-  iops                                = "1000"
+  # db_cluster_instance_class           = "db.r6gd.xlarge"
+  # storage_type                        = "io1"
+  # allocated_storage                   = "100"
+  # iops                                = "1000"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   backup_retention_period             = var.backup_retention_period

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "rds_aurora_read_replica" {
   engine_version        = aws_rds_cluster.rds_cluster[0].engine_version
   instance_class        = var.instance_class  # Specify the desired instance type
   db_subnet_group_name  = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
-  replicate_source_db   = "${aws_rds_cluster_instance.rds_cluster_instance[count.index]}"
+  replicate_source_db = aws_rds_cluster.rds_cluster[0].cluster_identifier
   
   tags = merge(local.common_tags, tomap({ "Name" : "${local.project_name_prefix}-read-replica" }))
 }

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,6 @@ resource "aws_db_instance" "rds_instance" {
   backup_retention_period    = var.backup_retention_period
   username                   = var.master_username
   # password                   = var.master_password
-  # password                   = random_string.rds_db_password.result
   password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
   db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
   vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   database_name                       = var.database_name == "" ? local.default_database_name : var.database_name
   allocated_storage                   = 256
   db_cluster_instance_class           = "db.r6gd.large"
-  iops                                = 2500
+  # iops                                = 2500
   storage_type                        = "io1"
   master_username                     = var.master_username
   master_password                     = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password

--- a/main.tf
+++ b/main.tf
@@ -77,33 +77,20 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
 
 
 resource "aws_db_instance" "rds_cluster_instance_read_replica" {
-  count                      = var.create_aurora ? 0 : 1
-  publicly_accessible        = var.publicly_accessible
-  allocated_storage          = var.allocated_storage
-  max_allocated_storage      = var.max_allocated_storage
-  storage_type               = var.storage_type
-  engine                     = var.engine
-  engine_version             = var.engine_version
-  identifier                 = local.project_name_prefix
-  instance_class             = var.instance_class
-  db_name                    = var.database_name == "" ? local.default_database_name : var.database_name
-  backup_retention_period    = var.backup_retention_period
-  username                   = var.master_username
-  # password                   = var.master_password
-  password                   = var.create_username_password ? random_string.rds_db_password[0].result : var.master_password
-  db_subnet_group_name       = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : var.subnet_group_name
-  vpc_security_group_ids     = var.create_security_group ? [aws_security_group.security_group[0].id] : var.security_group_ids
-  apply_immediately          = var.apply_immediately
-  storage_encrypted          = var.storage_encrypted
-  kms_key_id                 = var.storage_encrypted ? aws_kms_key.kms_key[0].arn : null
-  deletion_protection        = var.deletion_protection
-  maintenance_window         = var.maintenance_window
-  backup_window              = var.preferred_backup_window
-  skip_final_snapshot        = var.skip_final_snapshot
-  auto_minor_version_upgrade = var.auto_minor_version_upgrade
-  parameter_group_name       = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
-
-  replicate_source_db        = aws_rds_cluster_instance.rds_cluster_instance[0].arn
+  count                        = var.create_aurora ? 1 : 0
+  identifier                   = local.project_name_prefix
+  cluster_identifier           = aws_rds_cluster.rds_cluster[0].cluster_identifier
+  engine                       = aws_rds_cluster.rds_cluster[0].engine
+  engine_version               = aws_rds_cluster.rds_cluster[0].engine_version
+  db_subnet_group_name         = aws_rds_cluster.rds_cluster[0].db_subnet_group_name
+  db_parameter_group_name      = var.create_db_parameter_group ? aws_db_parameter_group.parameter_group[0].name : var.db_parameter_group_name
+  instance_class               = var.instance_class
+  preferred_maintenance_window = var.maintenance_window
+  apply_immediately            = var.apply_immediately
+  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
+  publicly_accessible          = var.publicly_accessible
+  tags                         = merge(local.common_tags, tomap({ "Name" : local.project_name_prefix }))
+  replicate_source_db          = aws_rds_cluster_instance.rds_cluster_instance[0].arn
 }
 
 resource "aws_db_instance" "rds_instance" {


### PR DESCRIPTION
Key changes made in this pull request:

1) Added Read Replica for Aurora Cluster and MySQL: A new Read Replica has been added for both the Aurora Cluster and the single MySQL DB instance. This Read Replica will serve as an additional read-only database instance, in order to offload read traffic from the primary instance.

2) Enabled Multi-AZ: Multi-AZ support has been enabled for both the Aurora Cluster and the single MySQL DB instance. This will ensure high availability by replicating data across multiple availability zones.

3) Error Fixes: Resolved some minor errors related to password creation.